### PR TITLE
Document accessibility features in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,31 @@ This package includes a collection of accessible themes for pygments based on di
 
 ![Screenshot of all dark themes side by side](./docs/dark_themes.png)
 
-Our current themes include,
+## WCAG 2.1 - AAA compliant
 
-- `a11y-light`
-- `a11y-dark`
-- `a11y-high-contrast-light`
-- `a11y-high-contrast-dark`
-- `pitaya-smoothie`
-- `github-light`
-- `github-dark`
-- `github-light-colorblind`
-- `github-dark-colorblind`
-- `github-light-high-contrast`
-- `github-dark-high-contrast`
-- `gotthard-light`
-- `gotthard-dark`
-- `blinds-light`
-- `blinds-dark`
-- `greative`
+The following themes are AAA compliant with [WCAG 2.1 criteria for color contrast](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html).
+
+- [`a11y-dark`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/a11y_dark)
+- [`a11y-high-contrast-dark`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/a11y_high_contrast_dark)
+- [`pitaya-smoothie`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/pitaya_smoothie) - Colorblindness friendly.
+- [`github-light`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/github_light) - Colorblindness friendly.
+- [`github-dark`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/github_dark) - Colorblindness friendly.
+- [`github-light-colorblind`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/github_light_colorblind) - Colorblindness friendly.
+- [`github-dark-colorblind`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/github_dark_colorblind) - Colorblindness friendly.
+- [`github-light-high-contrast`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/github_light_high_contrast) - Colorblindness friendly.
+- [`github-dark-high-contrast`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/github_dark_high_contrast) - Colorblindness friendly.
+- [`gotthard-dark`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/gotthard-dark) - Colorblindness friendly.
+
+## WCAG 2.1 - AA compliant
+
+The following themes are AA compliant with [WCAG 2.1 criteria for color contrast](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html).
+
+- [`a11y-light`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/a11y_light)
+- [`a11y-high-contrast-light`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/a11y_high_contrast_light)
+- [`gotthard-light`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/gotthard-light) - Colorblindness friendly.
+- [`blinds-light`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/blinds-light) - Colorblindness friendly.
+- [`blinds-dark`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/blinds-dark) - Colorblindness friendly.
+- [`greative`](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/greative) - Accessible to most forms of colorblindness and low light settings.
 
 For a demo of all our themes please [click here!](https://quansight-labs.github.io/accessible-pygments/)
 
@@ -84,4 +91,3 @@ We want to thank the following sources for being the source of inspiration of on
 - [gotthard vscode themes](https://github.com/janbiasi/vscode-gotthard-theme/).
 - [blinds vscode themes](https://github.com/orbulant/blinds-theme).
 - [greative vscode theme](https://github.com/SumanKhdka/Greative-VSCode-Theme).
-


### PR DESCRIPTION
This PR fixes #21 by,

- [x] Organizing the themes in the main readme by WCAG compliance (AAA/AA)
- [x] Adds links to individual readmes where more information is provided per theme
- [x] Adds a short description if the color theme is colorblindness friendly when present  