### PR TITLE
Exclude "test" package from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup (
 
   url='https://github.com/Quansight-Labs/accessible-pygments',
 
-  packages=find_packages(),
+  packages=find_packages(exclude=['test']),
   install_requires=[
     'pygments >= 1.5'
   ],


### PR DESCRIPTION
Add `test` to excludes for `find_packages()`, to prevent the package from wrongly installing the `test` directory into site-packages, e.g.:

    /usr/lib/python3.11/site-packages/test