### PR TITLE
[DOC] Remove conda instructions from contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,16 +68,6 @@ You will need to have the following installed locally:
    └─────────┴─────────┴──────────────┴─────────────┘
    ```
 
-Alternatively you can use conda to create your environment:
-
-```bash
-conda create -n a11y-pygments-dev python=3.9
-conda activate a11y-pygments-dev
-pip install -e .
-```
-
-After running these instructions you will have an environment named `a11y-pygments-dev`, with a development version of the package installed.
-
 ### Running the tests
 
 You can run the tests directly with hatch:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This package includes a collection of accessible themes for pygments based on mu
 ## Accessibility details ♿️
 
 > **Note**
-> What do we mean by accessible? In this context we are specially referring to themes which meet the [WCAG 2.1 criteria for color contrast](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
+> What do we mean by accessible? In this context we are specifically referring to themes which meet the [WCAG 2.1 criteria for color contrast](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
 > Some themes included are also color-blind friendly.
 
 ### WCAG 2.1 - AAA compliant
@@ -69,7 +69,7 @@ You can install it through the following commands:
 ```bash
 conda install -c conda-forge accessible-pygments
 
-# if you prefer using mambga
+# if you prefer using mamba
 mamba install -c conda-forge accessible-pygments
 ```
 


### PR DESCRIPTION
Fixes #37.

All of the other commands in the doc assume you have Hatch installed, so it seems out of place to include instructions for Conda.