### PR TITLE
ENH - Update release action

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -2,16 +2,12 @@ name: Build and maybe upload PyPI package
 
 on:
     push:
-        branches:
-            - main
-        tags:
-            - "*"
+        branches: [main]
+        tags: ["*"]
     pull_request:
-        branches:
-            - main
+        branches: [main]
     release:
-        types:
-        - published
+        types: [published]
     workflow_dispatch:
 
 env:
@@ -19,7 +15,6 @@ env:
 
 permissions:
     contents: read
-    id-token: write
 
 jobs:
     # Always build and lint
@@ -28,50 +23,56 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Checkout repository 🛎
-              uses: actions/checkout@v3
+            - name: "Checkout repository 🛎"
+              uses: actions/checkout@v4
               with:
                 fetch-depth: 0
 
-            - uses: hynek/build-and-inspect-python-package@v1
+            - name: "Build and inspect package 🛠"
+              uses: hynek/build-and-inspect-python-package@v2
 
     # Upload to Test PyPI on every commit on main.
     release-test-pypi:
         name: Publish in-dev package to test.pypi.org
         environment: release-test-pypi
+        permissions:
+            id-token: write
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
         needs: build-package
 
         steps:
-            - name: Download package built in previous job 📥
-              uses: actions/download-artifact@v3
+            - name: "Download package built in previous job 📥"
+              uses: actions/download-artifact@v4
               with:
                 name: Packages
                 path: dist
-            - name: Upload package to Test PyPI 🚀
+            - name: "Upload package to Test PyPI 🚀"
               uses: pypa/gh-action-pypi-publish@release/v1
               with:
-                password: ${{ secrets.TEST_PYPI_API_TOKEN }}
                 repository-url: https://test.pypi.org/legacy/
 
     # Upload to real PyPI on GitHub Releases.
     release-pypi:
         name: Publish released package to pypi.org 🚀
-        environment: release-pypi
-        if: github.event.action == 'published'
+        environment:
+            name: release-pypi
+            url: https://pypi.org/project/accessible-pygments/
+        permissions:
+            id-token: write
+        if: github.repository_owner == 'Quansight-Labs' && github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
         runs-on: ubuntu-latest
         needs: build-package
 
         steps:
-            - name: Download packages built by build-and-inspect-python-package 📥
-              uses: actions/download-artifact@v3
+            - name: "Download packages built in previous job 📥"
+              uses: actions/download-artifact@v4
               with:
                 name: Packages
                 path: dist
 
-            - name: Upload package to PyPI 🚀
+            - name: "Upload package to PyPI 🚀"
               uses: pypa/gh-action-pypi-publish@release/v1
               with:
-                password: ${{ secrets.PYPI_API_TOKEN }}
                 print-hash: true
+                verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,21 @@
 
 - MAINT - Add pre-commits and update docs by @trallard in https://github.com/Quansight-Labs/accessible-pygments/pull/26
 - ENH - Move to hatch for dev/build by @trallard in https://github.com/Quansight-Labs/accessible-pygments/pull/27
-- [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/Quansight-Labs/accessible-pygments/pull/28
-- [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/Quansight-Labs/accessible-pygments/pull/29
-- Delete docs/all_themes.pptx by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/40
+- MAINT - Delete docs/all_themes.pptx by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/40
 - [DOC] Remove conda instructions from contributing by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/39
-- Remove build artifacts from the repo by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/41
-- Automate theme READMEs by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/42
+- ENH - Remove build artifacts from the repo by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/41
+- ENH - Automate theme READMEs by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/42
 - MAINT - Miscellaneous updates by @trallard in https://github.com/Quansight-Labs/accessible-pygments/pull/46
 - BUG - Ensure no local version by @trallard in https://github.com/Quansight-Labs/accessible-pygments/pull/48
-- Automate theme README screenshots by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/43
+- ENH - Automate theme README screenshots by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/43
 - MAINT - Update pre-commit hooks by @trallard in https://github.com/Quansight-Labs/accessible-pygments/pull/45
-- [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/Quansight-Labs/accessible-pygments/pull/49
-- Fix contrast failures for high contrast light theme by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/33
-- Fix broken theme URLs in README, typo in demo html by @meli-lewis in https://github.com/Quansight-Labs/accessible-pygments/pull/53
-- Update code to not get images from placeholder.com by @Carreau in https://github.com/Quansight-Labs/accessible-pygments/pull/51
-- Reflect that rgb colors are in 0-1 and floats. by @Carreau in https://github.com/Quansight-Labs/accessible-pygments/pull/52
-- Small refactor of color utils for readibility and type checkability by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/55
-- Rename hex to float function by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/57
-- Set a11y-light default background to #f2f2f2 (light gray) by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/56
+- BUG - Fix contrast failures for high contrast light theme by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/33
+- ENH -Fix broken theme URLs in README, typo in demo html by @meli-lewis in https://github.com/Quansight-Labs/accessible-pygments/pull/53
+- ENH - Update code to not get images from placeholder.com by @Carreau in https://github.com/Quansight-Labs/accessible-pygments/pull/51
+- ENH -Reflect that rgb colors are in 0-1 and floats. by @Carreau in https://github.com/Quansight-Labs/accessible-pygments/pull/52
+- ENH - Small refactor of color utils for readibility and type checkability by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/55
+- ENH - Rename hex to float function by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/57
+- ENH - Set a11y-light default background to #f2f2f2 (light gray) by @gabalafou in https://github.com/Quansight-Labs/accessible-pygments/pull/56
 
 ### New Contributors
 


### PR DESCRIPTION
Before cutting a new package release, I updated the release workflow to use trusted publishers for releases moving forward. 

I also bumped a few of our actions running on outdated versions.